### PR TITLE
Update console.h to increase qemu refresh rate to 120hz (promotion)

### DIFF
--- a/include/ui/console.h
+++ b/include/ui/console.h
@@ -25,7 +25,7 @@
 #define QEMU_CAPS_LOCK_LED   (1 << 2)
 
 /* in ms */
-#define GUI_REFRESH_INTERVAL_DEFAULT    30
+#define GUI_REFRESH_INTERVAL_DEFAULT     8
 #define GUI_REFRESH_INTERVAL_IDLE     3000
 
 /* Color number is match to standard vga palette */


### PR DESCRIPTION
Apologies if I'm doing this all wrong, I don't commit to open-source much - but I think this is a worthwhile and very small change. By default QEMU's display is set to 75hz which is great for... almost no-one.

By changing this parameter QEMU's refresh rate will be 120hz which will look awesome on apple promotion displays and will still look better than 75hz on standard 60hz displays as the amount of frames is dividable by an even number.

Ideally upstream should make this a parameter but that hasn't happened for at least 2 or 3 full versions of QEMU and I think this default of 120hz is much better suited to the Apple ecosystem.

Also see:
[Original issue on qemu gitlab](https://gitlab.com/qemu-project/qemu/-/issues/700)